### PR TITLE
Use dub as a build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.exe
 *.obj
+*.o
 *.lib
 *.map
 *.asm

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,65 @@
+{
+    "name": "ylink",
+    "description": "Experimental OMF linker written in D.",
+    "version": "0.1.0",
+
+    "copyright": "Copyright © 2014, Daniel Murphy",
+    "license": "boost",
+    "authors": [
+        "Daniel 'yebblies' Murphy",
+        "see github for more"
+    ],
+
+    "dependencies": {},
+
+    "-ddoxFilterArgs": [ "--unittest-examples" ],
+
+    "targetPath": "bin",
+    "sourcePaths": [ "." ],
+    "importPaths": [ "." ],
+
+    "configurations": [
+        {
+            "name": "ylink",
+            "targetName": "ylink",
+            "sourceFiles": [ "ylink.d" ],
+            "excludedSourceFiles": [ "olink.d", "deblink.d", "debdump.d", "map2sym.d", "pedump.d", "test*" ],
+            "targetType": "executable"
+        },
+        {
+            "name": "olink",
+            "targetName": "olink",
+            "sourceFiles": [ "olink.d" ],
+            "excludedSourceFiles": [ "ylink.d", "deblink.d", "debdump.d", "map2sym.d", "pedump.d", "test*" ],
+            "targetType": "executable"
+        },
+        {
+            "name": "deblink",
+            "targetName": "deblink",
+            "sourceFiles": [ "deblink.d", "psapi.lib" ],
+            "excludedSourceFiles": [ "ylink.d", "olink.d", "debdump.d", "map2sym.d", "pedump.d", "test*" ],
+            "targetType": "executable"
+        },
+        {
+            "name": "debdump",
+            "targetName": "debdump",
+            "sourceFiles": [ "debdump.d" ],
+            "excludedSourceFiles": [ "ylink.d", "olink.d", "deblink.d", "map2sym.d", "pedump.d", "test*" ],
+            "targetType": "executable"
+        },
+        {
+            "name": "map2sym",
+            "targetName": "map2sym",
+            "sourceFiles": [ "map2sym.d" ],
+            "excludedSourceFiles": [ "ylink.d", "olink.d", "deblink.d", "debdump.d", "pedump.d", "test*" ],
+            "targetType": "executable"
+        },
+        {
+            "name": "pedump",
+            "targetName": "pedump",
+            "sourceFiles": [ "pedump.d" ],
+            "excludedSourceFiles": [ "ylink.d", "olink.d", "deblink.d", "debdump.d", "map2sym.d", "test*" ],
+            "targetType": "executable"
+        }
+    ]
+}


### PR DESCRIPTION
This moves the files to a "source" subfolder, allowing for a latter, less flat package.

It also switch to dub as a build system for the executables, but not the various tests.

Which "link" command is expected at line 52 ? I thought it was optlink, but it didn't compile on my machine.

Please let me know if there is anything you dislike about this.
