### PR TITLE
Fixed driver from parsing object files multiple times

### DIFF
--- a/cofflibraryfile.d
+++ b/cofflibraryfile.d
@@ -31,7 +31,7 @@ public:
         writeln("COFF Library file: ", f.filename);
         f.seek(0);
     }
-    override void loadSymbols(SymbolTable symtab, SectionTable sectab, WorkQueue!string queue, WorkQueue!ObjectFile objects)
+    override void loadSymbols(SymbolTable symtab, SectionTable sectab, ObjectFiles objectFiles)
     {
         //writeln("COFF Library file: ", f.filename);
         //symtab.dumpUndefined();
@@ -125,7 +125,7 @@ public:
                     auto obj = ObjectFile.detectFormat(new DataFile(f, offset));
                     assert(obj);
                     // writeln("Pulling in object ", cast(string)name, " due to undefined symbol: ", cast(string)sym.name);
-                    obj.loadSymbols(symtab, sectab, queue, objects);
+                    obj.loadSymbols(symtab, sectab, objectFiles);
                     progress = true;
                     break;
                 }

--- a/coffobjectfile.d
+++ b/coffobjectfile.d
@@ -243,12 +243,12 @@ public:
             i += sym.NumberOfAuxSymbols;
         }
     }
-    override void loadSymbols(SymbolTable xsymtab, SectionTable sectab, WorkQueue!string queue, WorkQueue!ObjectFile objects)
+    override void loadSymbols(SymbolTable xsymtab, SectionTable sectab, ObjectFiles objectFiles)
     {
         debug(COFFDATA) writeln("COFF Object file: ", f.filename);
 
         symtab = new SymbolTable(xsymtab);
-        objects.append(this);
+        objectFiles.putObjectFile(this);
 
         loadStuffFromFile();
 
@@ -260,7 +260,7 @@ public:
                 symtab.add(sym);
 
         foreach(d; directives)
-            d.apply(queue);
+            d.apply(objectFiles);
 
         symtab.checkUnresolved();
         symtab.merge();
@@ -486,12 +486,12 @@ public:
     {
         assert(0);
     }
-    override void loadSymbols(SymbolTable xsymtab, SectionTable sectab, WorkQueue!string queue, WorkQueue!ObjectFile objects)
+    override void loadSymbols(SymbolTable xsymtab, SectionTable sectab, ObjectFiles objectFiles)
     {
         debug(COFFDATA) writeln("COFF Import file: ", f.filename);
 
         symtab = new SymbolTable(xsymtab);
-        objects.append(this);
+        objectFiles.putObjectFile(this);
         f.seek(0);
 
         auto ch = f.read!CoffHeader();

--- a/directive.d
+++ b/directive.d
@@ -2,13 +2,14 @@
 import std.path;
 
 import workqueue;
+import objectfile;
 
 class Directive
 {
     this()
     {
     }
-    void apply(WorkQueue!string queue)
+    void apply(ObjectFiles objectFiles)
     {
         assert(0);
     }
@@ -21,9 +22,9 @@ class LibDirective : Directive
     {
         this.name = name;
     }
-    override void apply(WorkQueue!string queue)
+    override void apply(ObjectFiles objectFiles)
     {
-        queue.append(defaultExtension(cast(string)name, "lib"));
+        objectFiles.putName(defaultExtension(cast(string)name, "lib"));
     }
 }
 
@@ -34,7 +35,7 @@ class NoLibDirective : Directive
     {
         this.name = name;
     }
-    override void apply(WorkQueue!string queue)
+    override void apply(ObjectFiles objectFiles)
     {
     }
 }

--- a/driver.d
+++ b/driver.d
@@ -1,5 +1,6 @@
 
 import std.exception;
+import std.string;
 import std.stdio;
 
 import relocation;
@@ -12,26 +13,27 @@ import linker;
 import paths;
 import datafile;
 
-WorkQueue!ObjectFile loadObjects(string[] objFilenames, Paths paths, SymbolTable symtab, SectionTable sectab)
+void loadObjects(ObjectFiles objectFiles, Paths paths, SymbolTable symtab, SectionTable sectab)
 {
-    auto queue = new WorkQueue!string();
-    foreach(filename; objFilenames)
-        queue.append(filename);
-
-    auto objects = new WorkQueue!ObjectFile();
-    while (!queue.empty())
+    while (!objectFiles.emptyNames())
     {
-        auto filename = queue.pop();
+        string filename = objectFiles.popName();
+
         if (!paths.search(filename))
             writeln("Warning - File not found: " ~ filename);
         else
         {
+            //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            // Uncomment this once the verbosity pull request is merged
+            //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            //if (verbosity > 0)
+            //    debug writefln("verbose: Loading '%s'", filename);
+
             auto object = ObjectFile.detectFormat(new DataFile(filename));
             enforce(object, "Unknown object file format: " ~ filename);
-            object.loadSymbols(symtab, sectab, queue, objects);
+            object.loadSymbols(symtab, sectab, objectFiles);
         }
     }
-    return objects;
 }
 
 void finalizeLoad(SymbolTable symtab, SectionTable sectab)
@@ -42,14 +44,13 @@ void finalizeLoad(SymbolTable symtab, SectionTable sectab)
     symtab.checkUnresolved();
 }
 
-Segment[SegmentType] generateSegments(WorkQueue!ObjectFile objects, SymbolTable symtab, SectionTable sectab)
+Segment[SegmentType] generateSegments(ObjectFiles objectFiles, SymbolTable symtab, SectionTable sectab)
 {
     auto segments = sectab.allocateSegments(imageBase, segAlign, fileAlign);
     symtab.buildImports(segments[SegmentType.Import].data, imageBase);
 
-    while (!objects.empty())
+    foreach (ObjectFile object; objectFiles.objectFiles.data)
     {
-        auto object = objects.pop();
         object.loadData((SegmentType.TLS in segments) ? segments[SegmentType.TLS].base : -1);
     }
     return segments;

--- a/mlink.d
+++ b/mlink.d
@@ -10,6 +10,7 @@ import std.string;
 import linker;
 import paths;
 import driver;
+import objectfile;
 import pe;
 import sectiontable;
 import symboltable;
@@ -82,9 +83,10 @@ void main(string[] args)
     auto sectab = new SectionTable();
     auto symtab = new SymbolTable(null);
     symtab.setEntry(cast(immutable(ubyte)[])"_mainCRTStartup");
-    auto objects = loadObjects(objFilenames, paths, symtab, sectab);
+    ObjectFiles objectFiles = new ObjectFiles(objFilenames);
+    loadObjects(objectFiles, paths, symtab, sectab);
     finalizeLoad(symtab, sectab);
-    auto segments = generateSegments(objects, symtab, sectab);
+    auto segments = generateSegments(objectFiles, symtab, sectab);
 
     if (false)
     {

--- a/objectfile.d
+++ b/objectfile.d
@@ -42,33 +42,30 @@ class ObjectFiles
     public bool emptyNames() { return queue.empty(); }
     public string popName() { return queue.pop(); }
     public void putName(string name)
-	{
+    {
         string keyName = baseName(name).toLower();
         ObjectFilename* existing = keyName in keyNameObjectMap;
 
         if(existing !is null)
         {
             //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-			// Uncomment this once the verbosity pull request is merged
-			//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            // Uncomment this once the verbosity pull request is merged
+            //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             //if(verbosity > 0)
             //{
             //    writefln("verbose: ObjectFile '%s' already exists (keyName='%s')", name, keyName);
             //}
 
             // TODO: should I check if the paths are different?
-
         }
-		else
-		{
-
+        else
+        {
             keyNameObjectMap[keyName] = ObjectFilename(name, keyName);
             queue.append(name);
-
         }
     }
     public void putObjectFile(ObjectFile objectFile)
-	{
+    {
         objectFiles.put(objectFile);
     }
 }

--- a/olink.d
+++ b/olink.d
@@ -10,6 +10,7 @@ import std.string;
 import linker;
 import paths;
 import driver;
+import objectfile;
 import pe;
 import sectiontable;
 import symboltable;
@@ -130,9 +131,10 @@ void main(string[] args)
 
     auto sectab = new SectionTable();
     auto symtab = new SymbolTable(null);
-    auto objects = loadObjects(objFilenames, paths, symtab, sectab);
+    ObjectFiles objectFiles = new ObjectFiles(objFilenames);
+    loadObjects(objectFiles, paths, symtab, sectab);
     finalizeLoad(symtab, sectab);
-    auto segments = generateSegments(objects, symtab, sectab);
+    auto segments = generateSegments(objectFiles, symtab, sectab);
 
     if (dump)
     {

--- a/omflibraryfile.d
+++ b/omflibraryfile.d
@@ -29,7 +29,7 @@ public:
         writeln("OMF Library file: ", f.filename);
         f.seek(0);
     }
-    override void loadSymbols(SymbolTable symtab, SectionTable sectab, WorkQueue!string queue, WorkQueue!ObjectFile objects)
+    override void loadSymbols(SymbolTable symtab, SectionTable sectab, ObjectFiles objectFiles)
     {
         //writeln("OMF Library file: ", f.filename);
         //symtab.dumpUndefined();
@@ -93,7 +93,7 @@ public:
                     auto obj = ObjectFile.detectFormat(new DataFile(f, page * pagesize));
                     assert(obj);
                     //writeln("Pulling in object ", page, " due to undefined symbol: ", cast(string)sym.name);
-                    obj.loadSymbols(symtab, sectab, queue, objects);
+                    obj.loadSymbols(symtab, sectab, objectFiles);
                     progress = true;
                     break;
                 }

--- a/omfobjectfile.d
+++ b/omfobjectfile.d
@@ -44,12 +44,12 @@ public:
             r.dump();
         }
     }
-    override void loadSymbols(SymbolTable xsymtab, SectionTable sectab, WorkQueue!string queue, WorkQueue!ObjectFile objects)
+    override void loadSymbols(SymbolTable xsymtab, SectionTable sectab, ObjectFiles objectFiles)
     {
         debug(OMFDATA) writeln("OMF Object file: ", f.filename);
 
         symtab = new SymbolTable(xsymtab);
-        objects.append(this);
+        objectFiles.putObjectFile(this);
         f.seek(0);
         enforce(f.peekByte() == 0x80, "First record must be THEADR");
         auto modend = false;
@@ -90,7 +90,7 @@ public:
                     // DOSSEG
                     break;
                 case 0x9F:
-                    queue.append(defaultExtension(cast(string)data, "lib"));
+                    objectFiles.putName(defaultExtension(cast(string)data, "lib"));
                     break;
                 case 0xA0:
                     auto subtype = getByte(data);

--- a/ylink.d
+++ b/ylink.d
@@ -58,12 +58,17 @@ void main(string[] args)
             break;
         }
     }
+	
+    //
+    // Add object filenames
+    //
+    ObjectFiles objectFiles = new ObjectFiles(objectFilenames);
 
     auto sectab = new SectionTable();
     auto symtab = new SymbolTable(null);
-    auto objects = loadObjects(objectFilenames, paths, symtab, sectab);
+    loadObjects(objectFiles, paths, symtab, sectab);
     finalizeLoad(symtab, sectab);
-    auto segments = generateSegments(objects, symtab, sectab);
+    auto segments = generateSegments(objectFiles, symtab, sectab);
 
     if (dump)
     {


### PR DESCRIPTION
The new ObjectFiles class keeps track of which object files were already parsed and prevents driver.d from parsing the same object file twice.
